### PR TITLE
Current spree_editor extension requires Spree >= 0.70.0 

### DIFF
--- a/spree_editor.gemspec
+++ b/spree_editor.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency('spree_core', '>= 0.40.0')
+  s.add_dependency('spree_core', '>= 0.70.0')
 end


### PR DESCRIPTION
I tried to install on 0.60.3, but Rails won't start (missing Deface gem, amongst other things).

Fortunately, the version file put me on the right track and I have installed from an earlier commit (da5c7fcb980d39a2e0f71a7f132463c28ef8c665). 

I've modified the gemspec to show that the spree version dependency is higher.

Let me know if you need anything else. 
