### PR TITLE
Small invalid HTML

### DIFF
--- a/app/overrides/add_rich_editor_link.rb
+++ b/app/overrides/add_rich_editor_link.rb
@@ -4,4 +4,4 @@ Deface::Override.new(:virtual_path => "admin/configurations/index",
                      :text => "<tr>
       <td><%= link_to t(\"rich_editor\"), admin_editor_settings_path %></td>
       <td><%= t(\"rich_editor_description\") %></td>
-      </ tr>")
+      </tr>")


### PR DESCRIPTION
There is a small invalid `</ tr>` closing tag which generates `tr&gt;` code in admin Configuration page.
