### PR TITLE
JS code should go inside the head.

### DIFF
--- a/app/overrides/include_rich_text_js.rb
+++ b/app/overrides/include_rich_text_js.rb
@@ -1,4 +1,4 @@
 Deface::Override.new(:virtual_path => "layouts/admin",
                      :name => "include_rich_text_js",
-                     :insert_after => "[data-hook='admin_inside_head'], #admin_inside_head[data-hook]",
+                     :insert_bottom => "[data-hook='admin_inside_head'], #admin_inside_head[data-hook]",
                      :text => "<%= render :partial => 'shared/rich_editor_javascript' %>")


### PR DESCRIPTION
Using :insert_after puts the JS between the body and head tags, which creates invalid HTML. It should go inside the head, hence :insert_bottom.
