### PR TITLE
Removing file and image models to fix product images

### DIFF
--- a/app/models/content_file.rb
+++ b/app/models/content_file.rb
@@ -1,5 +1,0 @@
-class ContentFile < Asset
-  has_attached_file :attachment,
-    :url => "/assets/content_files/:id/:basename.:extension",
-    :path => ":rails_root/public/assets/content_files/:id/:basename.:extension"
-end

--- a/app/models/content_image.rb
+++ b/app/models/content_image.rb
@@ -1,7 +1,0 @@
-class ContentImage < Image
-  has_attached_file :attachment, 
-    :styles => {:mini => '48x48#', :large => '600x600>'},
-    :default_style => :large,
-    :url => "/assets/content_images/:id/:style/:basename.:extension",
-    :path => ":rails_root/public/assets/content_images/:id/:style/:basename.:extension"
-end


### PR DESCRIPTION
Product images had incorrect path in HTML and so were not showing. This commit reflects [one made to the version 1 branch](https://github.com/spree/spree_editor/commit/2065593e6dd911c60cc3f7e1b385b88e265e5f93). 
