### PR TITLE
spree dependency changes to ~>1.0.0

### DIFF
--- a/spree_editor.gemspec
+++ b/spree_editor.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('tinymce-rails', '>= 3.4.7.0.1')
-  s.add_dependency('spree_core', '= 1.0.0')
+  s.add_dependency('spree_core', '~> 1.0.0')
 
 end


### PR DESCRIPTION
tested. works on spree 1.0.1
