### PR TITLE
CKEditor support

### DIFF
--- a/app/views/shared/editor_engines/_ck_editor.html.erb
+++ b/app/views/shared/editor_engines/_ck_editor.html.erb
@@ -1,0 +1,13 @@
+<%= javascript_include_tag('ckeditor/init') %>
+
+<script type="text/javascript">
+  $(function() {
+    var ids = [<%= raw ids.map{|id| "'#{id}'"}.join(', ') %>];
+    for(var key in ids){
+      if($('#' + ids[key]).length > 0){
+        CKEDITOR.replace(ids[key]);
+      }
+    }
+  });
+</script>
+

--- a/lib/spree_editor.rb
+++ b/lib/spree_editor.rb
@@ -17,5 +17,5 @@ module SpreeEditor
     config.to_prepare &method(:activate).to_proc
   end
 
-  EditorEngines = %w(WYMEditor TinyMCE)
+  EditorEngines = %w(WYMEditor TinyMCE CKEditor)
 end

--- a/spree_editor.gemspec
+++ b/spree_editor.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency('tinymce-rails', '>= 3.4.7.0.1')
+  s.add_dependency('ckeditor')
   s.add_dependency('spree_core', '>= 1.0.0')
 
 end


### PR DESCRIPTION
It can be useful, because image upload feature can be easily added with [ckeditor](https://github.com/galetahub/ckeditor) gem:

gem 'spree_editor', :git => 'git://github.com/secoint/spree_editor.git', :branch => 'ckeditor'
gem 'ckeditor'

rails generate ckeditor:install --orm=active_record --backend=paperclip
rake db:migrate
