### PR TITLE
Issue #36 - Fixed the editor css overflow in the product description page.

### DIFF
--- a/lib/templates/config/tinymce.yml
+++ b/lib/templates/config/tinymce.yml
@@ -1,18 +1,26 @@
+# Spree Editor TinyMCE Configuration
+#
+# These are the options that will automatically be passed into the tinyMCE.init function
+# whenever TinyMCE is loaded in one of your spring pages. Please edit this file to
+# customise your TinyMCE setup in your spree installation. If you wish to see the full
+# range of configuration options then please go here:
+#
+#    http://www.tinymce.com/wiki.php/configuration
+
+# TinyMCE Options
 mode : "exact"
 theme : "advanced"
 language : "<%= I18n.locale.to_s.split('-')[0].downcase %>"
 skin : "o2k7"
-width : "594"
 plugins : "safari,style,layer,table,advhr,advimage,inlinepopups,insertdatetime,preview,media,searchreplace,contextmenu,paste,directionality,fullscreen,noneditable,visualchars,nonbreaking,xhtmlxtras,template"
 
 # Theme options
-theme_advanced_buttons1 : "cut,copy,paste,pastetext,pasteword,|,search,replace,|,undo,redo,|,link,unlink,anchor,image,cleanup,help,code,|,insertdate,inserttime,preview,|,fullscreen,|,charmap,media,advhr,|,visualchars,blockquote"
+theme_advanced_buttons1 : "cut,copy,paste,pastetext,pasteword,|,search,replace,|,undo,redo,|,link,unlink,anchor,image,cleanup,help,code,|,insertdate,inserttime,preview"
 theme_advanced_buttons2 : "bold,italic,underline,strikethrough,|,justifyleft,justifycenter,justifyright,justifyfull,|,sub,sup,|,bullist,numlist,|,outdent,indent,blockquote,|,"
 theme_advanced_buttons3 : "styleselect,formatselect,fontselect,fontsizeselect,|,forecolor,backcolor"
 theme_advanced_buttons4 : "tablecontrols,|,hr,removeformat,visualaid"
+theme_advanced_buttons5 : "fullscreen,|,charmap,media,advhr,|,visualchars,blockquote"
 theme_advanced_toolbar_location : "top"
 theme_advanced_toolbar_align : "left"
 theme_advanced_statusbar_location : "top"
 theme_advanced_resizing : false
-
-


### PR DESCRIPTION
**Important:** I have raised this PR against 1-3-stable. You may want to merge it into master as well.

In this change I also fixed the larger problem of people not realising that they have the power to configure tinymce.

I have also removed the width field because it automatically sets itself to the width of the text area that it is replacing. This is a really good default and should be the one that we use. People can customise this later if they choose to.

[Please see here for more information.](https://github.com/spree/spree_editor/issues/36#issuecomment-16006873)
