### PR TITLE
Issue #39 - Activate Raw Product Description if it is present.

### DIFF
--- a/app/controllers/spree/admin/editor_settings_controller.rb
+++ b/app/controllers/spree/admin/editor_settings_controller.rb
@@ -16,7 +16,9 @@ class Spree::Admin::EditorSettingsController < Spree::Admin::BaseController
       config[name] = value
     end
 
-    Spree::Config[:show_raw_product_description] = config[:enabled]
+    if Spree::Config.has_preference? :show_raw_product_description
+      Spree::Config[:show_raw_product_description] = config[:enabled]
+    end
 
     redirect_to admin_editor_settings_path
   end

--- a/lib/spree_editor/engine.rb
+++ b/lib/spree_editor/engine.rb
@@ -10,7 +10,10 @@ module SpreeEditor
 
     initializer "spree_editor.preferences", :before => :load_config_initializers do |app|
       SpreeEditor::Config = Spree::EditorConfiguration.new
-      Spree::Config[:show_raw_product_description] = SpreeEditor::Config[:enabled]
+
+      if Spree::Config.has_preference? :show_raw_product_description
+        Spree::Config[:show_raw_product_description] = SpreeEditor::Config[:enabled]
+      end
     end
 
     config.autoload_paths += %W(#{config.root}/lib)


### PR DESCRIPTION
This pull request is dependent on [another pull request in Spree Core](https://github.com/spree/spree/pull/2874) which I am hoping gets accepted.

This change fixes Issue #39 but it is implemented in a way that the code still remains backwards compatible with older versions of Spree. It can be back-ported to any version that you want as a result. It also means that you can merge this in right now and it will not cause any problems. I would recommend that it is brought into the branches 1-3-stable and master. 

I would also suggest that you update the README file and let people know that, in order for the CK Editor to work correctly, they need to a version of spree that contains this preference fix.

This change contains no tests, sorry about that one. I hope that you like it though and please let me know if I can fix anything. Cheers and thanks for spree_editor! It rocks, I love it.
