### PR TITLE
Deface the partial shared/rich_editor_javascript into admin_footer_scrip...

### DIFF
--- a/app/overrides/include_rich_text_js.rb
+++ b/app/overrides/include_rich_text_js.rb
@@ -1,4 +1,4 @@
 Deface::Override.new(:virtual_path => "spree/layouts/admin",
                      :name => "include_rich_text_js",
-                     :insert_bottom => "[data-hook='admin_inside_head'], #admin_inside_head[data-hook]",
+                     :insert_bottom => "[data-hook='admin_footer_scripts']",
                      :text => "<%= render :partial => 'shared/rich_editor_javascript' %>")


### PR DESCRIPTION
...ts instead of admin_inside_head to ensure that the editor javascript is loaded after jQuery
