### PR TITLE
make ckeditor work with rails 4 assets pipeline in production

### DIFF
--- a/app/views/shared/editor_engines/_ck_editor.html.erb
+++ b/app/views/shared/editor_engines/_ck_editor.html.erb
@@ -1,3 +1,26 @@
+<script>
+	window['CKEDITOR_BASEPATH'] = "/assets/ckeditor/";
+
+	window.CKEDITOR_ASSETS_MAPPING = {
+	<% Rails.application.assets.each_logical_path(->(path){ path =~ /ckeditor/ && path != 'ckeditor/override.js' }) do |asset| %>
+	  "<%= asset %>": "<%= asset_path(asset) %>",
+	<% end %>
+	}
+
+	window.CKEDITOR_GETURL = function( resource ) {
+	  // If this is not a full or absolute path.
+	  if ( resource.indexOf( ':/' ) == -1 && resource.indexOf( '/' ) !== 0 )
+	    resource = this.basePath + resource;
+
+	  // Add the timestamp, except for directories.
+	  if ( resource.charAt( resource.length - 1 ) != '/'  ){
+	    var url = resource.match( /^(.*?:\/\/[^\/]*)\/assets\/(.+)/ );
+	    if(url) resource = (CKEDITOR_ASSETS_MAPPING[url[2]] || '/assets/' + url[2]);
+	  }
+
+	  return resource;
+	}
+</script>
 <%= javascript_include_tag 'ckeditor/init' %>
 
 <script>


### PR DESCRIPTION
Ckeditor was not loading for me in a production environment using the assets pipeline.

The CKeditor readme suggests to include 'ckeditor/overrides' in the application.js directives, but unfortunately this won't work in a javascript_include_tag as for some reason override.js is not propagating to the store app.

While not ideal, copying and pasting the contents of override.js.erb from ckeditor into _ck_editor.html.erb works well.

Tested manually locally and in a production server using the rails assets pipeline.
