### PR TITLE
update ckeditor dependency to 4.0.11

### DIFF
--- a/spree_editor.gemspec
+++ b/spree_editor.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'ckeditor', '4.0.6'
+  s.add_dependency 'ckeditor', '4.0.11'
   s.add_dependency 'spree_backend', '~> 2.2.0'
   s.add_dependency 'tinymce-rails', '~> 3.5.8.3'
 


### PR DESCRIPTION
fixes issue with using CKEditor on 2-2-stable where you can't install the CKEditor.
