### PR TITLE
Update install instructions and fix Travis CI badge for 2-3-stable branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spree Editor
 
-[![Build Status](https://api.travis-ci.org/spree/spree_editor.png?branch=master)](https://travis-ci.org/spree/spree_editor)
+[![Build Status](https://travis-ci.org/spree-contrib/spree_editor.svg?branch=2-3-stable)](https://travis-ci.org/spree-contrib/spree_editor)
 [![Code Climate](https://codeclimate.com/github/spree/spree_editor.png)](https://codeclimate.com/github/spree/spree_editor)
 
 This extension provides an inline rich-text editor for Spree. It implements different types of editors:


### PR DESCRIPTION
Branch master require 'spree_backend', '~> 2.4.0.beta'
