### PR TITLE
Fix Travis CI badge for 2-2-stable branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spree Editor
 
-[![Build Status](https://api.travis-ci.org/spree/spree_editor.png?branch=2-2-stable)](https://travis-ci.org/spree/spree_editor)
+[![Build Status](https://travis-ci.org/spree-contrib/spree_editor.svg?branch=2-2-stable)](https://travis-ci.org/spree-contrib/spree_editor)
 [![Code Climate](https://codeclimate.com/github/spree/spree_editor.png)](https://codeclimate.com/github/spree/spree_editor)
 
 This extension provides an inline rich-text editor for Spree. It implements different types of editors:


### PR DESCRIPTION
The badge points to the 2-2-stable branch build status on travis ci
