### PR TITLE
improved README.md adding precompile ckeditor in assets.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ This extension provides an inline rich-text editor for Spree. It implements diff
   config.authorize_with :cancan, Spree::Ability
   ```
 
+5. In order to precompile CKEditor's generated assets, you will need to add a line in config/initializers/assets.rb:
+  ```ruby
+  Rails.application.config.assets.precompile += %w( ckeditor/*)
+  ```
 ---
 
 ## Configuration


### PR DESCRIPTION
As proposed by JDutil [there:](https://github.com/spree-contrib/spree_editor/issues/77)
Adding a new step in the installation guide.