### PR TITLE
Upgrade to CKEditor ~> 4.1.1

### DIFF
--- a/spree_editor.gemspec
+++ b/spree_editor.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'ckeditor',      '~> 4.0.11'
+  s.add_dependency 'ckeditor',      '~> 4.1.1'
   s.add_dependency 'spree_backend', '~> 2.4.0'
   s.add_dependency 'tinymce-rails', '~> 4.0.16'
 


### PR DESCRIPTION
If I try to upload an image using "CKEditor Files Manager" (popup browser), I get this error: 

````
ActionController::RoutingError (No route matches [POST] "/ckeditor/EDITOR.config.filebrowserImageUploadUrl")
```

This is solved in this pull request: https://github.com/galetahub/ckeditor/pull/373/files