### PR TITLE
Remove hardcoded CKEDITOR_BASEPATH

### DIFF
--- a/app/views/shared/editor_engines/_ck_editor.html.erb
+++ b/app/views/shared/editor_engines/_ck_editor.html.erb
@@ -1,7 +1,3 @@
-<script>
-	window['CKEDITOR_BASEPATH'] = "/assets/ckeditor/";
-</script>
-
 <%= javascript_include_tag 'ckeditor/init' %>
 
 <script>


### PR DESCRIPTION
I had to remove these lines so I was able to set my own basepath.

Default is already `/assets/ckeditor`