### PR TITLE
sass-rails version upgrade to ~> 5.0.0

### DIFF
--- a/lib/spree_editor/version.rb
+++ b/lib/spree_editor/version.rb
@@ -8,10 +8,10 @@ module SpreeEditor
   end
 
   module VERSION
-    MAJOR = 2
-    MINOR = 2
-    TINY  = 1
-    PRE   = nil
+    MAJOR = 3
+    MINOR = 1
+    TINY  = 0
+    PRE   = 'beta'.freeze
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
   end

--- a/spree_editor.gemspec
+++ b/spree_editor.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner', '~> 1.3.0'
   s.add_development_dependency 'factory_girl', '~> 4.4'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'sass-rails', '~> 4.0.2'
+  s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'poltergeist', '~> 1.5.0'
   s.add_development_dependency 'simplecov', '~> 0.9.0'


### PR DESCRIPTION
sass-rails version upgrade to 5.0.0 as 4.0.2's sass version (3.2.0) conflicts with spree's bootstrap-sass's sass (3.2.19) version.

Bump version to 3.1.0.beta