### PR TITLE
Add tinymce-jquery.js to assets.precompile, bump version to 3.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', github: 'spree/spree', branch: '3-1-stable'
 
 gemspec

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( tinymce-jquery.js )

--- a/lib/spree_editor/version.rb
+++ b/lib/spree_editor/version.rb
@@ -11,7 +11,7 @@ module SpreeEditor
     MAJOR = 3
     MINOR = 1
     TINY  = 0
-    PRE   = 'beta'.freeze
+    PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
   end


### PR DESCRIPTION
- Add tinymce-jquery.js to assets.precompile
- bump version to 3.1.0
- change spree branch to 3-1-stable