### PR TITLE
Set spree_backend to >= 3.1.0 and < 4.0 versions

### DIFF
--- a/spree_editor.gemspec
+++ b/spree_editor.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'ckeditor',      '~> 4.1.2'
-  s.add_dependency 'spree_backend', '~> 3.2.0.alpha'
+  s.add_dependency 'spree_backend', '>= 3.1.0', '< 4.0'
   s.add_dependency 'tinymce-rails', '~> 4.2.5'
 
   s.add_development_dependency 'i18n-spec', '>= 0.5.0'


### PR DESCRIPTION
This PR changes the version of `spree_backend` in gemspec to point at `>= 3.1.0` and `< 4.0`.