### PR TITLE
Make deface use spree namespace for edit_admin_editor_settings_path.

### DIFF
--- a/app/overrides/add_rich_editor_tab.rb
+++ b/app/overrides/add_rich_editor_tab.rb
@@ -2,5 +2,5 @@ Deface::Override.new(
   virtual_path: 'spree/admin/shared/sub_menu/_configuration',
   name: 'add_rich_editor_tab',
   insert_bottom: '[data-hook="admin_configurations_sidebar_menu"]',
-  text: '<li<%== " class=\"active\"" if controller.controller_name == "editor_settings" %>><%= link_to Spree.t(:rich_editor), edit_admin_editor_settings_path %></li>'
+  text: '<li<%== " class=\"active\"" if controller.controller_name == "editor_settings" %>><%= link_to Spree.t(:rich_editor), spree.edit_admin_editor_settings_path %></li>'
 )


### PR DESCRIPTION
Fix error for scenario where `configurations` submenu is accessed from a route outside of spree namespace.